### PR TITLE
tests: add fuse interface spread test

### DIFF
--- a/tests/lib/snaps/fuse-consumer/Makefile
+++ b/tests/lib/snaps/fuse-consumer/Makefile
@@ -1,0 +1,9 @@
+# -*- Mode: Makefile; indent-tabs-mode:t; tab-width: 4 -*-
+
+all:
+
+install:
+	mkdir -p $(DESTDIR)/bin
+	cp -a hello.py $(DESTDIR)/bin/create
+	cp -a _find_fuse_parts.py $(DESTDIR)/bin
+	chmod a+x $(DESTDIR)/bin/create

--- a/tests/lib/snaps/fuse-consumer/_find_fuse_parts.py
+++ b/tests/lib/snaps/fuse-consumer/_find_fuse_parts.py
@@ -1,0 +1,22 @@
+import sys, os, glob
+from os.path import realpath, dirname, join
+from traceback import format_exception
+
+ddd = realpath(join(dirname(sys.argv[0]), '..'))
+
+for d in [ddd, '.']: 
+    for p in glob.glob(join(d, 'build', 'lib.*')):
+        sys.path.insert(0, p)
+
+try:
+    import fuse
+except ImportError:
+    raise RuntimeError, """
+
+! Got exception:
+""" + "".join([ "> " + x for x in format_exception(*sys.exc_info()) ]) + """
+! Have you ran `python setup.py build'?
+!
+! We've done our best to find the necessary components of the FUSE bindings
+! even if it's not installed, we've got no clue what went wrong for you...
+"""

--- a/tests/lib/snaps/fuse-consumer/hello.py
+++ b/tests/lib/snaps/fuse-consumer/hello.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+
+#    Copyright (C) 2006  Andrew Straw  <strawman@astraw.com>
+#
+#    This program can be distributed under the terms of the GNU LGPL.
+#    See the file COPYING.
+#
+
+import os, stat, errno
+# pull in some spaghetti to make this stuff work without fuse-py being installed
+try:
+    import _find_fuse_parts
+except ImportError:
+    pass
+import fuse
+from fuse import Fuse
+
+
+if not hasattr(fuse, '__version__'):
+    raise RuntimeError, \
+        "your fuse-py doesn't know of fuse.__version__, probably it's too old."
+
+fuse.fuse_python_api = (0, 2)
+
+hello_path = '/hello'
+hello_str = 'Hello World!\n'
+
+class MyStat(fuse.Stat):
+    def __init__(self):
+        self.st_mode = 0
+        self.st_ino = 0
+        self.st_dev = 0
+        self.st_nlink = 0
+        self.st_uid = 0
+        self.st_gid = 0
+        self.st_size = 0
+        self.st_atime = 0
+        self.st_mtime = 0
+        self.st_ctime = 0
+
+class HelloFS(Fuse):
+
+    def getattr(self, path):
+        st = MyStat()
+        if path == '/':
+            st.st_mode = stat.S_IFDIR | 0755
+            st.st_nlink = 2
+        elif path == hello_path:
+            st.st_mode = stat.S_IFREG | 0444
+            st.st_nlink = 1
+            st.st_size = len(hello_str)
+        else:
+            return -errno.ENOENT
+        return st
+
+    def readdir(self, path, offset):
+        for r in  '.', '..', hello_path[1:]:
+            yield fuse.Direntry(r)
+
+    def open(self, path, flags):
+        if path != hello_path:
+            return -errno.ENOENT
+        accmode = os.O_RDONLY | os.O_WRONLY | os.O_RDWR
+        if (flags & accmode) != os.O_RDONLY:
+            return -errno.EACCES
+
+    def read(self, path, size, offset):
+        if path != hello_path:
+            return -errno.ENOENT
+        slen = len(hello_str)
+        if offset < slen:
+            if offset + size > slen:
+                size = slen - offset
+            buf = hello_str[offset:offset+size]
+        else:
+            buf = ''
+        return buf
+
+def main():
+    usage="""
+Userspace hello example
+
+""" + Fuse.fusage
+    server = HelloFS(version="%prog " + fuse.__version__,
+                     usage=usage,
+                     dash_s_do='setsingle')
+
+    server.parse(errex=1)
+    server.main()
+
+if __name__ == '__main__':
+    main()

--- a/tests/lib/snaps/fuse-consumer/snapcraft.yaml
+++ b/tests/lib/snaps/fuse-consumer/snapcraft.yaml
@@ -1,0 +1,17 @@
+name: fuse-consumer
+version: 1.0
+summary: Basic fuse consumer snap
+description: A basic snap declaring a plug on fuse
+
+apps:
+    create:
+        command: bin/create
+        plugs: [fuse]
+
+parts:
+    create:
+        plugin: python2
+        stage-packages: [python-fuse]
+    make:
+        plugin: make
+        source: .

--- a/tests/main/interfaces-fuse/task.yaml
+++ b/tests/main/interfaces-fuse/task.yaml
@@ -1,0 +1,62 @@
+summary: Ensure that the fuse interface works.
+
+details: |
+    The fuse interfac allows a snap to manage FUSE file systems.
+
+    A snap which defines the fuse plug must be shown in the interfaces list.
+    The plug must be autoconnected on install and, as usual, must be able to be
+    reconnected.
+
+    A snap declaring a plug on this interface must be able to create a fuse filesystem
+    in a writable zone. The fuse-consumer test snap creates a readable file with a known
+    name and content in the mount point given to the command.
+
+environment:
+    BUILD_DIR: $(mktemp -d)
+    MOUNT_POINT: /var/snap/fuse-consumer/current/mount_point
+
+prepare: |
+    echo "Given a snap declaring a fuse plug is installed"
+    mkdir -p $BUILD_DIR
+    apt install -y snapcraft
+    cp -ar $TESTSLIB/snaps/fuse-consumer/* $BUILD_DIR
+    cd $BUILD_DIR && snapcraft
+    snap install fuse-consumer_1.0_$(dpkg-architecture -q DEB_HOST_ARCH).snap
+
+    echo "And a user writable mount point is created"
+    mkdir -p $MOUNT_POINT
+    chown test:test $MOUNT_POINT
+
+restore: |
+    apt remove -y snapcraft
+    apt autoremove -y
+    umount $MOUNT_POINT
+    rm -rf $BUILD_DIR $MOUNT_POINT fuse.error
+
+execute: |
+    CONNECTED_PATTERN=":fuse +fuse-consumer"
+    DISCONNECTED_PATTERN="(?s).*?\n- +fuse-consumer:fuse"
+
+    echo "Then the fuse plug is connected by default"
+    snap interfaces | grep -Pzq "$CONNECTED_PATTERN"
+
+    echo "==================================="
+
+    echo "When the plug is connected"
+    snap connect fuse-consumer:fuse ubuntu-core:fuse
+
+    echo "Then the snap is able to create a fuse filesystem"
+    sudo -i -u test /bin/sh -c "fuse-consumer.create $MOUNT_POINT"
+    grep -q "Hello World!" $MOUNT_POINT/hello
+
+    echo "==================================="
+
+    echo "When the plug is disconnected"
+    snap disconnect fuse-consumer:fuse ubuntu-core:fuse
+
+    echo "Then the snap is not able to create a fuse file system"
+    if sudo -i -u test /bin/sh -c "fuse-consumer $MOUNT_POINT 2>${PWD}/fuse.error"; then
+        echo "Expected permission error creating fuse filesystem with disconnected plug"
+        exit 1
+    fi
+    grep -q "Permission denied" fuse.error

--- a/tests/main/interfaces-fuse/task.yaml
+++ b/tests/main/interfaces-fuse/task.yaml
@@ -42,15 +42,6 @@ execute: |
 
     echo "==================================="
 
-    echo "When the plug is connected"
-    snap connect fuse-consumer:fuse ubuntu-core:fuse
-
-    echo "Then the snap is able to create a fuse filesystem"
-    sudo -i -u test /bin/sh -c "fuse-consumer.create $MOUNT_POINT"
-    grep -q "Hello World!" $MOUNT_POINT/hello
-
-    echo "==================================="
-
     echo "When the plug is disconnected"
     snap disconnect fuse-consumer:fuse ubuntu-core:fuse
 
@@ -60,3 +51,12 @@ execute: |
         exit 1
     fi
     grep -q "Permission denied" fuse.error
+
+    echo "==================================="
+
+    echo "When the plug is connected"
+    snap connect fuse-consumer:fuse ubuntu-core:fuse
+
+    echo "Then the snap is able to create a fuse filesystem"
+    sudo -i -u test /bin/sh -c "fuse-consumer.create $MOUNT_POINT"
+    grep -q "Hello World!" $MOUNT_POINT/hello

--- a/tests/main/interfaces-fuse/task.yaml
+++ b/tests/main/interfaces-fuse/task.yaml
@@ -1,7 +1,7 @@
 summary: Ensure that the fuse interface works.
 
 details: |
-    The fuse interfac allows a snap to manage FUSE file systems.
+    The fuse interface allows a snap to manage FUSE file systems.
 
     A snap which defines the fuse plug must be shown in the interfaces list.
     The plug must be autoconnected on install and, as usual, must be able to be


### PR DESCRIPTION
Hi @stgraber :) this is the test I mentioned. It uses the same structure of the interface spread tests that we are using so far, you can take a look at https://github.com/snapcore/snapd/tree/master/tests/main, all the tasks prefixed with `interfaces-`.

Usually we create the snaps with the snapbuild tool, built from source https://github.com/snapcore/snapd/tree/master/tests/lib/snapbuild, but for this test this shouldn't work, it is not able to add parts to a snap and in this case we require dependencies for being able to create a fuse filesystem. Maybe there's a better way of doing this than using python and pyhton-fuse, please let me know what do you think.

The test snap uses the hello.py example file that comes with python-fuse http://packages.ubuntu.com/xenial/amd64/python-fuse/filelist, it creates a fuse filesystem in the mount point given as parameter and a `hello` file in there with the `Hello World!` content. I've tried it locally, with the python-fuse package installed and it works fine.

However, the snap with the plug connected is failing, executing fuse-consumer.create with a path writable for the snap (under /var/snap/fuse-consumer/current for instance) returns `Bad system call`, from dmesg I get:
```
[30231.486673] audit: type=1326 audit(1469806014.829:353): auid=4294967295 uid=1000 gid=1000 ses=4294967295 pid=28553 comm="python" exe="/snap/fuse-consumer/x1/usr/bin/python2.7" sig=31 arch=c000003e syscall=165 compat=0 ip=0x7f42b3ab0e2a code=0x0
```
syscall 165 seems to be `mount` and the entr point `sys_mount`.

Please take a look at the `tests/main/interfaces-fuse/task.yaml` file in this changeset to see the exact steps to reproduce, let me know if something isn't clear.

Cheers!